### PR TITLE
fix notificatino logic

### DIFF
--- a/features/nav-menu/components/sidebar-nav-items.tsx
+++ b/features/nav-menu/components/sidebar-nav-items.tsx
@@ -8,7 +8,7 @@ import {
   ProfileIcon,
 } from "@/delphi-ui/icons";
 import { useTrainingQueue } from "@/features/mind-dialog";
-import { useTrainingState } from "@/hooks/use-training-state";
+import { isFinishedItemStatus } from "@/utils/training-status-helpers";
 import { SidebarAddButton } from "./sidebar-add-button";
 import { SidebarNavLink } from "./sidebar-nav-link";
 
@@ -28,9 +28,9 @@ export function SidebarNavItems({
   isActive,
   onAddClick,
 }: SidebarNavItemsProps) {
-  const { status } = useTrainingState();
-  const { markAsReviewed } = useTrainingQueue();
-  const hasNewTraining = status === "finished";
+  const { queue, markAsReviewed, hasUserReviewed } = useTrainingQueue();
+  const hasFinishedItems = queue.some((item) => isFinishedItemStatus(item.status));
+  const hasNewTraining = hasFinishedItems && !hasUserReviewed;
 
   const handleMindClick = () => {
     if (hasNewTraining) markAsReviewed();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refines the Mind tab notification logic to more accurately reflect training completion status.
> 
> - Replaces `useTrainingState` with `useTrainingQueue` and `isFinishedItemStatus` to compute `hasNewTraining` based on finished queue items and `hasUserReviewed`
> - Continues to call `markAsReviewed` when the Mind link is clicked if new training is present
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 900402eaac94855f6555b5d87039f2e7df7a12f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of new training items and notification display logic in the navigation menu.

* **Refactor**
  * Updated training status state management to use a more reliable item status evaluation approach.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->